### PR TITLE
Resolve o problema de não ter mais o repositorio baileys de adiwajshing.

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "author": "guiguicdd",
   "license": "MIT",
   "dependencies": {
-    "@adiwajshing/baileys": "github:adiwajshing/baileys",
+    "@adiwajshing/baileys": "github:WhiskeySockets/Baileys",
     "@adiwajshing/keyed-db": "^0.2.4",
     "@hapi/boom": "^10.0.0",
     "jimp": "^0.16.1",


### PR DESCRIPTION
Adiwajshing decidiu excluir o repositório Baileys por questões a qual não citarei nesta PR, porém a comunidade decidiu continuar com o projeto Baileys no repositório "WhiskeySockets".